### PR TITLE
Replacing KEYS command with SSCAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Built with:
 > **Note:** Pre-built applications are available on the [Releases](https://github.com/cloudflare/workerskv.gui/releases) page!
 
 You must have [Redis installed locally](https://redis.io/download) to use `localhost` servers.
+Alternatively, you can use the provided docker-compose file with:
+```bash
+docker-compose up -d
+```
 
 ***Local Development***
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+
+services:
+  redis:
+    image: "redis:alpine"
+    ports:
+      - "127.0.0.1:6379:6379"
+    expose:
+      - "6379"

--- a/src-tauri/src/redis.rs
+++ b/src-tauri/src/redis.rs
@@ -131,10 +131,13 @@ pub fn set(conn: &mut Connection, name: String, syncd: String, expires: Option<S
 	)
 }
 
+/**
+ * Filter an iterator over the set's keys.
+ */
 pub fn filter(conn: &mut Connection, pattern: String) -> Vec<String>  {
 	let iter: redis::Iter<String> = redis::cmd("SSCAN").arg(KEYLIST).cursor_arg(0).arg("MATCH").arg(&pattern)
 		.clone().iter(conn).expect(
-			&format!("unable to run 'KEYS {}' operation", &pattern)
+			&format!("unable to run 'SSCAN x MATCH {}' operation", &pattern)
 		);
 
 	iter.collect()

--- a/src-tauri/src/redis.rs
+++ b/src-tauri/src/redis.rs
@@ -132,9 +132,12 @@ pub fn set(conn: &mut Connection, name: String, syncd: String, expires: Option<S
 }
 
 pub fn filter(conn: &mut Connection, pattern: String) -> Vec<String>  {
-	redis::cmd("KEYS").arg(&pattern).query(conn).expect(
-		&format!("unable to run 'KEYS {}' operation", &pattern)
-	)
+	let iter: redis::Iter<String> = redis::cmd("SSCAN").arg(KEYLIST).cursor_arg(0).arg("MATCH").arg(&pattern)
+		.clone().iter(conn).expect(
+			&format!("unable to run 'KEYS {}' operation", &pattern)
+		);
+
+	iter.collect()
 }
 
 pub fn sort(conn: &mut Connection, to_desc: bool) -> Vec<String>  {


### PR DESCRIPTION
This is a follow up to this issue: https://github.com/cloudflare/workerskv.gui/issues/9.

This replaces the keys command with SSCAN. I've tested this in the UI with a simple glob pattern. I haven't seen any tests, but if there are some I'll be happy to update them.

Also included is a redis docker-compose, because I didn't have redis installed.